### PR TITLE
DemoSettingItem made struct instead of class.

### DIFF
--- a/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Components/ComponentsViewController.swift
+++ b/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Components/ComponentsViewController.swift
@@ -35,7 +35,7 @@ class ComponentsViewController: DemoTableViewController {
     
 
    func initializeComponentSection() {
-        var components: [AnyObject] = [AnyObject]()
+        var components = [DemoSettingItem]()
     
         if (ConnectedProductManager.sharedInstance.fetchAircraft() != nil){
             components.append(DemoSettingItem(name:"Flight Controller", andClass:nil))
@@ -53,7 +53,7 @@ class ComponentsViewController: DemoTableViewController {
     }
 
     func initializeMissionSection() {
-        var components: [AnyObject] = [AnyObject]()
+        var components = [DemoSettingItem]()
         
         if (ConnectedProductManager.sharedInstance.fetchHandheldController() != nil) {
             components.append(DemoSettingItem(name:"Panorama Mission", andClass:nil))

--- a/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Components/DemoUtility/UIUtility/DemoSettingItem.swift
+++ b/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Components/DemoUtility/UIUtility/DemoSettingItem.swift
@@ -6,21 +6,14 @@
 //  Copyright © 2015 DJI. All rights reserved.
 //
 import Foundation
-import DJISDK
+import UIKit
 
-class DemoSettingItem: NSObject {
+struct DemoSettingItem {
     var itemName: String = ""
     var viewControllerClass:UIViewController.Type? = nil
     
     init(name: String, andClass viewControllerClass: UIViewController.Type?) {
         self.itemName = name
         self.viewControllerClass = viewControllerClass
-        super.init()
-    }
-    
-    
-
-    class func initSettingItem(name: String, andClass viewControllerClass: UIViewController.Type) -> DemoSettingItem {
-        return DemoSettingItem(name: name, andClass: viewControllerClass)
     }
 }

--- a/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Components/DemoUtility/UIUtility/DemoTableViewController.swift
+++ b/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Components/DemoUtility/UIUtility/DemoTableViewController.swift
@@ -8,11 +8,48 @@
 import UIKit
 import DJISDK
 
+enum Items {
+    case plain([DemoSettingItem])
+    case groupped([[DemoSettingItem]])
+
+    init() {
+        self = .plain([])
+    }
+
+    func numberOfRowsInSection(section: Int) -> Int {
+        switch self {
+        case .plain(let itms):      return itms.count
+        case .groupped(let itms):   return itms[section].count
+        }
+    }
+
+    func item(indexPath: NSIndexPath) -> DemoSettingItem {
+        switch self {
+        case .plain(let itms):      return itms[indexPath.row]
+        case .groupped(let itms):   return itms[indexPath.section][indexPath.row]
+        }
+    }
+
+    func append(item: DemoSettingItem) {
+        switch self {
+        case .plain(var itms):  itms.append(item)
+        case .groupped:         print("not supposed to be called for groupped")
+        }
+    }
+
+    func append(item: [DemoSettingItem]) {
+        switch self {
+        case .plain:                print("not supposed to be called for plain")
+        case .groupped(var itms):   itms.append(item)
+        }
+    }
+}
+
 let HeaderHeight:CGFloat = 30
 
 class DemoTableViewController: UITableViewController, DJIBaseProductDelegate {
     var sectionNames:[AnyObject] = []
-    var items:[AnyObject] = []
+    var items:Items = Items()
     var connectedComponent:DJIBaseComponent? = nil
     
     var showComponentVersionSn:Bool = false
@@ -20,7 +57,7 @@ class DemoTableViewController: UITableViewController, DJIBaseProductDelegate {
     var serialNumber:String? = nil
     var versionSerialLabel:UILabel = UILabel(frame: CGRectZero)
 
-     init() {
+    init() {
         super.init(style: .Grouped)
     }
     
@@ -37,17 +74,7 @@ class DemoTableViewController: UITableViewController, DJIBaseProductDelegate {
     }
 
     override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if self.sectionNames.count <= 1 {
-            return self.items.count
-        }
-        else if (section < self.items.count) {
-            let items:[AnyObject]? = self.items[section] as? [AnyObject]
-            if (items != nil) {
-                return items!.count
-            }
-        }
-        
-        return 0;
+        return items.numberOfRowsInSection(section)
     }
 
     override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
@@ -65,25 +92,8 @@ class DemoTableViewController: UITableViewController, DJIBaseProductDelegate {
         if cell == nil {
             cell = UITableViewCell(style: .Default, reuseIdentifier: CellIdentifier)
         }
-        let section: Int = indexPath.section
-        let row: Int = indexPath.row
-        var item: DemoSettingItem? = nil
-        if self.sectionNames.count <= 1 {
-            item = self.items[row] as? DemoSettingItem
-            if (item == nil) {
-                let sectionItems = self.items[0] as? [DemoSettingItem]
-                if (sectionItems?.count > row) {
-                    item = sectionItems![row]
-                }
-            }
-        }
-        else {
-            let sectionItems = self.items[section] as? [DemoSettingItem]
-            if (sectionItems?.count > row) {
-                item = sectionItems![row]
-            }
-        }
-        cell?.textLabel!.text = item?.itemName
+        let item = items.item(indexPath)
+        cell?.textLabel!.text = item.itemName
         cell?.textLabel?.font = UIFont(name:"Helvetica Neue Light", size:18)
         cell?.accessoryType = .DisclosureIndicator
         return cell!
@@ -101,34 +111,10 @@ class DemoTableViewController: UITableViewController, DJIBaseProductDelegate {
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         // Navigation logic may go here. Create and push another view controller.
         tableView.deselectRowAtIndexPath(indexPath, animated: true)
-        let section: Int = indexPath.section
-        let row: Int = indexPath.row
-        var item: DemoSettingItem? = nil
-        if self.sectionNames.count <= 1 {
-            item = self.items[row] as? DemoSettingItem
-            if (item == nil) {
-                let sectionItems = self.items[0] as? [DemoSettingItem]
-                if (sectionItems?.count > row) {
-                    item = sectionItems![row]
-                }
-            }
-        }
-        else {
-            let sectionItems = self.items[section] as? [DemoSettingItem]
-            if (sectionItems?.count > row) {
-                item = sectionItems![row]
-            }
-        }
-        
-        if (item != nil) {
-            // If the view controller exists in stroy board, excuting the segue first
-            if (self.canPerformSegueWithIdentifier(item!.itemName)) {
-                self.performSegueWithIdentifier(item!.itemName, sender: self)
-            } else if (item!.viewControllerClass != nil) {
-                let controllerObject = item!.viewControllerClass!.init()
-                controllerObject.title = item?.itemName
-                self.navigationController!.pushViewController(controllerObject, animated: true)
-            }
+        let item = items.item(indexPath)
+        // If the view controller exists in stroy board, excuting the segue first
+        if (self.canPerformSegueWithIdentifier(item.itemName)) {
+            self.performSegueWithIdentifier(item.itemName, sender: self)
         }
     }
     


### PR DESCRIPTION
In DemoTableViewController.swift items property refactored into enum.
By its nature DemoSettingItem is value type so it fits into struct much better than into class.
items property in DemoTableViewController used to be [AnyObject] because it could be [DemoSettingItem] or [[DemoSettingItem]]. Here enums with associated values works better making items property obvious and it's usage straightforward.