### PR TITLE
Solves null dereference bug

### DIFF
--- a/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/Helper/DJIImageCalibrationFrame/DJIImageCalibrationFastFrame.m
+++ b/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/Helper/DJIImageCalibrationFrame/DJIImageCalibrationFastFrame.m
@@ -42,10 +42,8 @@
 -(void)loadFrame:(VideoFrameYUV*)videoFrame
       fastUpload:(BOOL)fastUpload{
     [self prepareToClean];
-    CGSize frameSize = CGSizeZero;
     VPFrameType frameType = VPFrameTypeYUV420Planer;
     if (videoFrame != NULL){
-        frameSize = CGSizeMake(videoFrame->width, videoFrame->height);
         frameType = videoFrame->frameType;
         if (videoFrame->cv_pixelbuffer_fastupload != NULL){
             self.fastUploadEnabled = YES;

--- a/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/Helper/DJIImageCalibrationFrame/DJIImageCalibrationFastFrame.m
+++ b/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/Helper/DJIImageCalibrationFrame/DJIImageCalibrationFastFrame.m
@@ -69,13 +69,13 @@
             self.fastUploadEnabled = NO;
             self.fastUploadType = kCVPixelFormatType_420YpCbCr8Planar;
         }
-    }
-    memcpy([self frame],videoFrame,sizeof(VideoFrameYUV));
-    if (videoFrame->cv_pixelbuffer_fastupload != NULL){
-        CVPixelBufferRetain(videoFrame->cv_pixelbuffer_fastupload);
-    }
-    else{
-        [self reconstructFastUploadFrame];
+        memcpy([self frame],videoFrame,sizeof(VideoFrameYUV));
+        if (videoFrame->cv_pixelbuffer_fastupload != NULL){
+            CVPixelBufferRetain(videoFrame->cv_pixelbuffer_fastupload);
+        }
+        else{
+            [self reconstructFastUploadFrame];
+        }
     }
 }
 

--- a/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/Helper/DJIImageCalibrationFrame/DJIImageCalibrationFastFrame.m
+++ b/Sample Code/DJIWidget/DJIWidget/VideoPreviewer/Helper/DJIImageCalibrationFrame/DJIImageCalibrationFastFrame.m
@@ -39,17 +39,17 @@
     return self;
 }
 
--(void)loadFrame:(VideoFrameYUV*)frame
+-(void)loadFrame:(VideoFrameYUV*)videoFrame
       fastUpload:(BOOL)fastUpload{
     [self prepareToClean];
     CGSize frameSize = CGSizeZero;
     VPFrameType frameType = VPFrameTypeYUV420Planer;
-    if (frame != NULL){
-        frameSize = CGSizeMake(frame->width, frame->height);
-        frameType = frame->frameType;
-        if (frame->cv_pixelbuffer_fastupload != NULL){
+    if (videoFrame != NULL){
+        frameSize = CGSizeMake(videoFrame->width, videoFrame->height);
+        frameType = videoFrame->frameType;
+        if (videoFrame->cv_pixelbuffer_fastupload != NULL){
             self.fastUploadEnabled = YES;
-            self.fastUploadType = CVPixelBufferGetPixelFormatType(frame->cv_pixelbuffer_fastupload);
+            self.fastUploadType = CVPixelBufferGetPixelFormatType(videoFrame->cv_pixelbuffer_fastupload);
         }
         else if (fastUpload){
             switch (frameType) {
@@ -72,9 +72,9 @@
             self.fastUploadType = kCVPixelFormatType_420YpCbCr8Planar;
         }
     }
-    memcpy([self frame],frame,sizeof(VideoFrameYUV));
-    if (frame->cv_pixelbuffer_fastupload != NULL){
-        CVPixelBufferRetain(frame->cv_pixelbuffer_fastupload);
+    memcpy([self frame],videoFrame,sizeof(VideoFrameYUV));
+    if (videoFrame->cv_pixelbuffer_fastupload != NULL){
+        CVPixelBufferRetain(videoFrame->cv_pixelbuffer_fastupload);
     }
     else{
         [self reconstructFastUploadFrame];


### PR DESCRIPTION
Renames method parameter to avoid variable shadowing which makes code clearer.
Removes local variable which wasn't used.
Moves code to avoid calling memcpy with second parameter NULL and dereferencing null in following condition check when videoFrame is null.
This solves two static analyzer issues.