### PR TITLE
Add NSBluetoothAlwaysUsageDescription and Silence the warning: 'withUnsafeBytes' is deprecated'

### DIFF
--- a/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Camera/VideoPreviewerAdapter.swift
+++ b/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Camera/VideoPreviewerAdapter.swift
@@ -337,10 +337,11 @@ extension VideoPreviewerAdapter: DJIVideoFeedListener {
             NSLog("ERROR: Wrong video feed update is received!");
             return
         }
-        videoData.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) in
-            let p = UnsafeMutablePointer<UInt8>.init(mutating: ptr)
-            previewer?.push(p, length: Int32(videoData.count))
-            
+        // In order to use withUnsafeMutableBytes, change to mutable variable
+        var videoData = videoData
+        videoData.withUnsafeMutableBytes { dataBytes in
+            let buffer: UnsafeMutablePointer = dataBytes.baseAddress!.assumingMemoryBound(to: UInt8.self)
+            previewer?.push(buffer, length: Int32(dataBytes.count))
         }
     }
     

--- a/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Info.plist
+++ b/Sample Code/SwiftSampleCode/DJISDKSwiftDemo/Info.plist
@@ -24,6 +24,8 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Use Bluetooth</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
- Add NSBluetoothAlwaysUsageDescription for SwiftDemo Project otherwise will crash
- Silence the warning: 'withUnsafeBytes' is deprecated:'